### PR TITLE
Improve Makefile for `top` proper

### DIFF
--- a/top/Makefile
+++ b/top/Makefile
@@ -1,9 +1,8 @@
 CFLAGS= -std=gnu99 -Wall -Wextra -O2 -march=native
 
-all : top cup
-
 top : top.o
 	$(CC) -o $@ $^ -lm
 
 clean :
 	rm -rf top.o *~
+


### PR DESCRIPTION
Sorry for the oversight in the first place (see #16). Now the Makefile should be perfectly right.
