### PR TITLE
Fix generation of scripts used in index.html

### DIFF
--- a/user.cfg
+++ b/user.cfg
@@ -24,7 +24,6 @@ OPTS += -DICACHE_FLASH
 #OPTS += -DFREQ=12500
 
 PAGE_TITLE = esp8266 ws2812 i2s controller
-PAGE_SCRIPT = <script language="javascript" type="text/javascript" src=main.js></script>
+PAGE_SCRIPTS = main.js
 PAGE_HEADING = $(PAGE_TITLE)
 PAGE_INFO = <p>Welcome to the esp8266ws2812i2s Web-based GUI.</p><p>This GUI uses WebSockets, and has only been tested under the newest (as of April, 2016) Chrome and Firefox browsers.</p><p>For more information about this project, visit it on github, here: <a href=https://github.com/cnlohr/esp8266ws2812i2s>https://github.com/cnlohr/esp8266ws2812i2s</a></p><p>If you want to send light to this device, send a UDP packet to port $(COM_PORT) to it.  The first 3 bytes will be ignored, after that will be GRB values, one byte each, for each WS2812 you want to control</p>
-

--- a/web/page/index.html
+++ b/web/page/index.html
@@ -1,6 +1,4 @@
 <html><head><title>{{PAGE_TITLE}}</title>
-<script language="javascript" type="text/javascript" src={{PAGE_JQUERYFL}}></script>
-<script language="javascript" type="text/javascript" src=menuinterface.js></script>
 {{PAGE_SCRIPT}}
 <meta charset="UTF-8">
 <style>


### PR DESCRIPTION
I was having issues with loading the page because `{{PAGE_JQUERYFL}}` doesn't get updated during build. This patch removes it because `PAGE_SCRIPTS` seems to do the same thing.

Offtopic: do you know why i had to change the `PAGE_OFFSET` to 1048576?